### PR TITLE
Set chunked encoding size on Jersey client to force use of HTTP chunking

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -518,7 +518,9 @@ public class ApiClient {
    */
   private Client getClient() {
     if(!hostMap.containsKey(basePath)) {
-      Client client = Client.create();
+      final ClientConfig config = new DefaultClientConfig();
+      config.getProperties().put(ClientConfig.PROPERTY_CHUNKED_ENCODING_SIZE, -1 /* default chunk size */);
+      Client client = Client.create(config);
       if (debugging)
         client.addFilter(new LoggingFilter());
       hostMap.put(basePath, client);


### PR DESCRIPTION
Via:
https://github.com/heroku/direct-to-heroku-client-java/commit/d009447e24ad5ac68050968eff482b5d2e05c1e0

See: https://github.com/heroku/direct-to-heroku-client-java/issues/6
See:
https://jersey.github.io/apidocs/1.18/jersey/com/sun/jersey/api/client/config/ClientConfig.html#PROPERTY_CHUNKED_ENCODING_SIZE